### PR TITLE
Se modifica el font para que cumpla con la plantilla en docx

### DIFF
--- a/autoformato/curso_pdf/tec.tex
+++ b/autoformato/curso_pdf/tec.tex
@@ -35,12 +35,10 @@
 \usepackage{setspace}
 
 %% Fuentes 
+%Fuente GWC Goticq (ocupa el paquete fonts-urw-base35)
+\usepackage{avant} 
+\renewcommand*\familydefault{\sfdefault}
 
-%Fuente Avantgarde
-%\usepackage{avant} 
-
-%Fuente Helvet
-\usepackage{helvet}
 
 \usepackage{mathptmx} 
 


### PR DESCRIPTION
La plantilla en docx tiene una fuente que es similar a URW Gothic.

Este cambio hace uso de ese fuente para la plantilla
